### PR TITLE
Implement vector quantization based on "Neural Discrete Representation Learning" paper

### DIFF
--- a/src/models/latent_action.py
+++ b/src/models/latent_action.py
@@ -7,7 +7,7 @@ from torch.nn.functional import mse_loss
 from einops.layers.torch import Rearrange
 from src.models.utils.modules import SpatialAttention, TemporalAttention
 from src.models.attentive_pooler import AttentivePooler
-from src.models.utils.quantization import LookupFreeQuantization
+from src.models.utils.quantization import LookupFreeQuantization, VectorQuantization
 from src.models.predictor import vit_predictor
 
 REPR_ACT_ENC = (
@@ -83,14 +83,21 @@ class LatentActionEncoder(nn.Module):
         # )
 
         # Build the quantization module
-        self.quant = LookupFreeQuantization(
-            input_dim           = inp_dims,
-            codebook_dim        = d_codebook,
-            num_codebook        = n_codebook,
-            use_bias            = lfq_bias,
-            commit_weight       = lfq_commit_weight,
-            entropy_weight      = lfq_entropy_weight,
-            diversity_weight    = lfq_diversity_weight,
+        # TODO: Refactor the parameters to match vector quantization instead of lookup-free quantization, e.g. change lfq_commit_weight to vq_commit_weight
+        # self.quant = LookupFreeQuantization(
+        #     input_dim           = inp_dims,
+        #     codebook_dim        = d_codebook,
+        #     num_codebook        = n_codebook,
+        #     use_bias            = lfq_bias,
+        #     commit_weight       = lfq_commit_weight,
+        #     entropy_weight      = lfq_entropy_weight,
+        #     diversity_weight    = lfq_diversity_weight,
+        # )
+        self.quant = VectorQuantization(
+            embedding_dim=d_codebook,
+            input_dim=inp_dims,
+            num_embeddings=n_codebook,
+            commitment_cost=lfq_commit_weight,
         )
         
         self.d_codebook = d_codebook

--- a/src/models/utils/quantization.py
+++ b/src/models/utils/quantization.py
@@ -8,13 +8,13 @@ from einops import einsum
 from einops import rearrange
 from einops import pack, unpack
 
-from torch.nn.functional import mse_loss
+import torch.nn.functional as F
 
 from typing import Tuple
 
 
-def entropy(p : Tensor, eps : float = 1e-6) -> Tensor:
-    '''Calculates the entropy of a probability distribution.
+def entropy(p: Tensor, eps: float = 1e-6) -> Tensor:
+    """Calculates the entropy of a probability distribution.
 
     Args:
         p (Tensor): The probability distribution.
@@ -23,105 +23,189 @@ def entropy(p : Tensor, eps : float = 1e-6) -> Tensor:
 
     Returns:
         Tensor: The entropy of the probability distribution.
-    '''
-    return - (p * log(p.clamp(min=eps))).sum(dim=-1)
+    """
+    return -(p * log(p.clamp(min=eps))).sum(dim=-1)
+
 
 # Simplified version of the myscience implementation at: https://github.com/myscience/open-genie
 class LookupFreeQuantization(nn.Module):
-    '''
+    """
     Lookup-Free Quantization module as originally introduced
     in the paper "Language Model Beats Diffusion: Tokenizer
     is key to visual generation" Yu et al. (2024).
-    '''
+    """
 
     def __init__(
         self,
-        codebook_dim : int,
-        input_dim : int,
-        num_codebook : int = 1,
-        use_bias : bool = True,
-        commit_weight : float = 0.25,
-        entropy_weight : float = 0.1,
-        diversity_weight : float = 1.,
+        codebook_dim: int,
+        input_dim: int,
+        num_codebook: int = 1,
+        use_bias: bool = True,
+        commit_weight: float = 0.25,
+        entropy_weight: float = 0.1,
+        diversity_weight: float = 1.0,
     ) -> None:
         super().__init__()
-        codebook_size = (2 ** codebook_dim) * num_codebook
+        codebook_size = (2**codebook_dim) * num_codebook
         project = input_dim != codebook_dim * num_codebook
-        
-        self.proj_inp = nn.Linear(input_dim, codebook_dim * num_codebook, bias=use_bias) if project else nn.Identity()
-        self.proj_out = nn.Linear(codebook_dim * num_codebook, input_dim, bias=use_bias) if project else nn.Identity()
-        
+
+        self.proj_inp = (
+            nn.Linear(input_dim, codebook_dim * num_codebook, bias=use_bias)
+            if project
+            else nn.Identity()
+        )
+        self.proj_out = (
+            nn.Linear(codebook_dim * num_codebook, input_dim, bias=use_bias)
+            if project
+            else nn.Identity()
+        )
+
         self.codebook_dim = codebook_dim
         self.num_codebooks = num_codebook
         self.codebook_size = codebook_size
         self.commit_weight = commit_weight
         self.entropy_weight = entropy_weight
         self.diversity_weight = diversity_weight
-        
+
         # * Initialize the codebook
         # Use the bit_mask to generate the bit-codes for all the codebook entries
         # and then convert them to the actual codebook values {-1, 1}. Resulting
         # codebook will have shape (codebook_size, d_codebook).
-        self.register_buffer('bit_mask', 2 ** torch.arange(codebook_dim - 1, -1, -1)) # if codebook_dim =8 than get tensor([128,  64,  32,  16,   8,   4,   2,   1])
-        
+        self.register_buffer(
+            "bit_mask", 2 ** torch.arange(codebook_dim - 1, -1, -1)
+        )  # if codebook_dim =8 than get tensor([128,  64,  32,  16,   8,   4,   2,   1])
+
         codes = torch.arange(codebook_size, dtype=int)[:, None] & self.bit_mask
-        self.register_buffer('codebook', 2 * (codes != 0).float() - 1, persistent=False)
+        self.register_buffer("codebook", 2 * (codes != 0).float() - 1, persistent=False)
 
     def forward(
-        self,
-        inp : Tensor,
-        beta : float = 100.,
-        transpose : bool = False
+        self, inp: Tensor, beta: float = 100.0, transpose: bool = False
     ) -> Tuple[Tuple[Tensor, Tensor], Tensor | None]:
-        
         # Standardize the input tensor to have shape (batch_size, seq_len, inp_dim)
-        inp = rearrange(inp, 'b d ... -> b ... d') if transpose else inp
-        inp, ps = pack([inp], 'b * d') # pack to b ... d
-        
+        inp = rearrange(inp, "b d ... -> b ... d") if transpose else inp
+        inp, ps = pack([inp], "b * d")  # pack to b ... d
+
         inp = self.proj_inp(inp)
-        
+
         # Split into n_codebook parts
-        inp = rearrange(inp, 'b n (c d) -> b n c d', c=self.num_codebooks)
+        inp = rearrange(inp, "b n (c d) -> b n c d", c=self.num_codebooks)
 
         # Quantize by simply assigning {-1, 1} to the input tensor depending on the sign
         # of the input tensor values. This is the lookup-free quantization step.
         # See Eq. (3) in the original paper. To obtain the quantized-code indices
         # we simply sum the bit-codes representation of the quantized values.
         quant = inp.sign()
-        idxs = reduce((inp > 0).int() * self.bit_mask.int(), 'b n c d -> b n c', 'sum')
-        
+        idxs = reduce((inp > 0).int() * self.bit_mask.int(), "b n c d -> b n c", "sum")
+
         # Use straight-through estimator to back-propagate through the quantization step
         code = (inp + (quant - inp).detach()) if self.training else quant
-        code = rearrange(code, 'b n c d -> b n (c d)')
-        
+        code = rearrange(code, "b n c d -> b n (c d)")
+
         # Reconstruct the input tensor from the quantized values
         out = self.proj_out(code)
-        out = unpack(out, ps, 'b * d')[0]
-        out = rearrange(out, 'b ... d -> b d ...') if transpose else out
+        out = unpack(out, ps, "b * d")[0]
+        out = rearrange(out, "b ... d -> b d ...") if transpose else out
 
         # NOTE: Squeeze to remove the n_codebook dimension
-        idxs = unpack(idxs, ps, 'b * d')[0].squeeze()
-
+        idxs = unpack(idxs, ps, "b * d")[0].squeeze()
 
         # No need to compute the loss if we are not training
-        if not self.training: return (out, idxs), None
-        
+        if not self.training:
+            return (out, idxs), None
+
         # Compute the entropy loss
-        inp_prob = 2 * einsum(inp, self.codebook, '... i d, j d -> ... i j')
+        inp_prob = 2 * einsum(inp, self.codebook, "... i d, j d -> ... i j")
         inp_prob = (inp_prob * beta).softmax(dim=-1)
-        inp_prob = rearrange(inp_prob, 'b n ... -> (b n) ...')
-        
-        avg_prob = reduce(inp_prob, '... c d -> c d', 'mean')
-        
+        inp_prob = rearrange(inp_prob, "b n ... -> (b n) ...")
+
+        avg_prob = reduce(inp_prob, "... c d -> c d", "mean")
+
         inp_ent = entropy(inp_prob).mean()
         avg_ent = entropy(avg_prob).mean()
-        
+
         entropy_loss = inp_ent + self.diversity_weight * avg_ent
-        
+
         # Compute commitment loss
-        commit_loss = mse_loss(inp, quant.detach(), reduction = 'mean')
-        
+        commit_loss = F.mse_loss(inp, quant.detach(), reduction="mean")
+
         # Compute the complete final loss
         loss = entropy_loss * self.entropy_weight + commit_loss * self.commit_weight
-        
+
         return (out, idxs), loss
+
+
+# Pytorch implementation of the official implementation at: https://github.com/google-deepmind/sonnet/blob/v1/sonnet/python/modules/nets/vqvae.py
+class VectorQuantization(nn.Module):
+    """
+    Vector Quantization module as originally introduced in the paper "Neural Discrete Representation Learning"
+    by van den Oord et al. (2017).
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        input_dim: int,
+        num_embeddings: int,
+        commitment_cost: float = 0.25,
+    ) -> None:
+        super().__init__()
+
+        self._embedding_dim = embedding_dim
+        self._num_embeddings = num_embeddings
+        self._commitment_cost = commitment_cost
+
+        self.in_proj = (
+            nn.Linear(input_dim, embedding_dim)
+            if input_dim != embedding_dim
+            else nn.Identity()
+        )
+        self.out_proj = (
+            nn.Linear(embedding_dim, input_dim)
+            if input_dim != embedding_dim
+            else nn.Identity()
+        )
+
+        self.codebook = nn.Embedding(num_embeddings, embedding_dim)
+        self.codebook.weight.data.uniform_(-1.0 / embedding_dim, 1.0 / embedding_dim)
+
+    def forward(
+        self,
+        inputs: Tensor,
+        transpose: bool = False,
+    ) -> tuple[tuple[Tensor, Tensor], Tensor | None]:
+        # Project the inputs to the codebook space
+        inputs = self.in_proj(inputs)
+
+        input_shape = inputs.shape
+        flat_inputs = inputs.view(-1, self._embedding_dim)
+
+        # Calculate distances
+        # (x - y)^2 = x^2 - 2xy + y^2
+        distances = (
+            (torch.sum(flat_inputs**2, dim=1, keepdim=True))
+            - 2 * torch.matmul(flat_inputs, self.codebook.weight.T)
+            + torch.sum(self.codebook.weight.T**2, dim=0, keepdim=True)
+        )
+
+        # Get the closest codebook index for each input
+        encoding_indices = torch.argmin(distances, dim=1)
+
+        # Reshape encoding_indices to match input dimensions except the last one
+        encoding_indices = encoding_indices.view(input_shape[:-1])
+
+        # Quantize the input based on the encoding indices
+        quantized = self.codebook(encoding_indices)
+
+        # Project the quantized values back to the input space
+        outputs = self.out_proj(quantized)
+
+        # No need to compute the loss if we are not training
+        if not self.training:
+            return (outputs, encoding_indices), None
+
+        # Vector quantization loss
+        e_latent_loss = F.mse_loss(quantized.detach(), inputs)
+        q_latent_loss = F.mse_loss(quantized, inputs.detach())
+        loss = q_latent_loss + self._commitment_cost * e_latent_loss
+
+        return (outputs, encoding_indices), loss


### PR DESCRIPTION
I've updated the vector quantization method to follow the original Genie paper more closely.

The new VQ implementation is basically a PyTorch re-implementation of the [official TensorFlow implementation](https://github.com/google-deepmind/sonnet/blob/v1/sonnet/python/modules/nets/vqvae.py) from DeepMind. With added input and output projection. 

I've tested this new implementation with `test/test_latent_model.py` and it seems to pass.

Note that I've left the hyperparameters such as `lfq_bias` unchanged, though only `lfq_commit_weight` are used in new VQ. We might need to refactor the parameters in the future once it is tested that the new VQ method works. 